### PR TITLE
Create mixins and clean tasks

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -36,12 +36,14 @@ gulp.task('css:minify', function() {
     .pipe(gulp.dest('dist'));
 });
 
-gulp.task('watch', function () {
+gulp.task('watch', ['build'], function () {
   gulp.watch('./src/**/*.scss', function () {
-    runSequence('sass:compile', 'css:minify')
+    runSequence('sass:compile', 'css:minify');
   });
 });
 
-gulp.task('default', function () {
+gulp.task('build', function () {
   runSequence('sass:compile', 'css:minify');
-})
+});
+
+gulp.task('default', ['watch']);

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,6 +1,5 @@
 const gulp = require('gulp');
 const sass = require('gulp-sass');
-const gutil = require('gulp-util');
 const rename = require('gulp-rename');
 const cleanCSS = require('gulp-clean-css');
 const runSequence = require('run-sequence');

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "gulp-cssbeautify": "^0.1.3",
     "gulp-rename": "^1.2.2",
     "gulp-sass": "^3.1.0",
-    "gulp-util": "^3.0.8",
     "run-sequence": "^1.2.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "url": "https://github.com/lucasgruwez/waffle-grid"
   },
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "start": "gulp",
+    "test": "gulp build"
   },
   "keywords": [
     "flexbox",

--- a/src/waffle-grid.scss
+++ b/src/waffle-grid.scss
@@ -165,4 +165,4 @@ $breakpoints: (
 		.#{$bp-name}-and-lower {display: none;}
 	}
 }
-// under 150 lines !!
+// under 170 lines !!

--- a/src/waffle-grid.scss
+++ b/src/waffle-grid.scss
@@ -33,7 +33,7 @@ $pulls: true !default;
 $breakpoints: (
 	m: (840px, (4, 6, 8)),
 	s: (480px, (4, 6)),
-);
+) !default;
 
 // Actual css, change this at your own risk
 

--- a/src/waffle-grid.scss
+++ b/src/waffle-grid.scss
@@ -37,18 +37,40 @@ $breakpoints: (
 
 // Actual css, change this at your own risk
 
-.#{$container-classname} {
-	width: $grid-width;
+
+@mixin build-container {
+  width: $grid-width;
 	max-width: $grid-max-width;
 	margin: 0 auto;
+};
+
+@mixin build-grid {
+  display: flex;
+	flex-direction: column;
+}
+
+@mixin build-row {
+  display: flex;
+	flex-direction: row;
+	width: 100%;
+	flex-wrap: wrap;
+}
+
+@mixin build-column {
+  box-sizing: border-box;
+  margin: $gutter-width / 2;
+  vertical-align: top;
+}
+
+// Actual css, change this at your own risk
+
+.#{$container-classname} {
+	@include build-container;
 }
 
 .#{$grid-classname} {
-	display: flex;
-	flex-direction: column;
-	width: $grid-width;
-	max-width: $grid-max-width;
-	margin: 0 auto;
+  @include build-grid;
+	@include build-container;
 	&.full-width {
 		width: 100%;
 		max-width: 100%;
@@ -56,17 +78,13 @@ $breakpoints: (
 }
 
 .#{$row-classname} {
-	display: flex;
-	flex-direction: row;
-	width: 100%;
-	flex-wrap: wrap;
+	@include build-row;
 }
 
 .#{$column-classname} {
-  box-sizing: border-box;
-  margin: $gutter-width / 2;
-  vertical-align: top;
+  @include build-column;
 }
+
 
 .center {margin-left: auto; margin-right: auto;}
 .left	  {margin-right: auto;}


### PR DESCRIPTION
Could be separate PRs if you wish. 

Using npm scripts is pretty standard now and means you don't have to install gulp globally. 
Instead you can run `npm start`. See https://docs.npmjs.com/misc/scripts

Was missing a `!default` on the `$breadpoints` var.  

Added mixins for each base grid class to enable extending easier.